### PR TITLE
add specific version for matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 networkx==1.11
-matplotlib
+matplotlib==2.2.3
 powerlaw
 datetime
 python-dateutil


### PR DESCRIPTION
With newest versions (3.1.1 in my case) visualization step fails with

```
The iterable function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use np.iterable instead.
  if not cb.iterable(width):
Traceback (most recent call last):
  File "scripts/visualize/plot_transaction_graph.py", line 84, in <module>
    plot_graph(g_)
  File "scripts/visualize/plot_transaction_graph.py", line 65, in plot_graph
    nx.draw_networkx_edges(g, pos)
  File "/Users/marcin.cylke/projects/hunter/graph-aml-exploration/AMLSim/venv/lib/python3.7/site-packages/networkx/drawing/nx_pylab.py", line 522, in draw_networkx_edges
    if not cb.is_string_like(edge_color) \
AttributeError: module 'matplotlib.cbook' has no attribute 'is_string_like'
```